### PR TITLE
reorganize trace schema, rename and add fields

### DIFF
--- a/contrib/reprocess_trace.exs
+++ b/contrib/reprocess_trace.exs
@@ -1,3 +1,4 @@
+import Ecto.Changeset
 import Ecto.Query
 alias Klaxon.Repo
 alias Klaxon.Traces.Processor
@@ -11,8 +12,19 @@ defmodule ReprocessTrace do
   def reprocess_trace_by_id(trace_id) do
     trace =
       Repo.get(Trace, trace_id)
+
+    processed_trace =
+      trace
       |> Repo.preload([:waypoints, tracks: [segments: :trackpoints]])
       |> Processor.preprocess_trace()
       |> Processor.process_trace()
+      |> Map.put(:profile_id, trace.profile_id)
+      |> Map.put(:visibility, :public)
+      |> Map.put(:status, :processed)
+      |> Repo.insert!()
+
+    trace
+    |> change(%{visibility: :unlisted})
+    |> Repo.update!()
   end
 end

--- a/lib/klaxon/traces/processor.ex
+++ b/lib/klaxon/traces/processor.ex
@@ -434,6 +434,8 @@ defmodule Klaxon.Traces.Processor do
     |> List.flatten()
   end
 
+  defp apply_assumed_step([{:go, [] = _go_trkpts} = p, _], _factor, _speed), do: p
+
   # Handles each incoming list of trackpoint groups, in pairs, except the last.
   defp apply_assumed_step(
          [{:go, go_trkpts}, {:stop, _stop_trkpts, {lon, lat} = _ctrpt}],

--- a/lib/klaxon/traces/processor.ex
+++ b/lib/klaxon/traces/processor.ex
@@ -11,7 +11,7 @@ defmodule Klaxon.Traces.Processor do
 
   @type go_or_stop() :: :go | :stop
   @type trace() :: %Trace{tracks: [Track.t()], waypoints: [Waypoint.t()]}
-  @type trackpoint() :: %Trackpoint{lon: float(), lat: float(), created_at: DateTime.t()}
+  @type trackpoint() :: %Trackpoint{lon: float(), lat: float(), time: DateTime.t()}
   @type trackpoints() :: [Trackpoint.t()]
   @type trackpoint_group() :: {go_or_stop(), trackpoints()}
   @type trackpoint_groups() :: [trackpoint_group()]
@@ -71,7 +71,7 @@ defmodule Klaxon.Traces.Processor do
       lat: trackpoint.lat,
       lon: trackpoint.lon,
       ele: trackpoint.ele,
-      created_at: trackpoint.created_at
+      time: trackpoint.time
     }
   end
 
@@ -81,7 +81,7 @@ defmodule Klaxon.Traces.Processor do
       lon: waypoint.lon,
       lat: waypoint.lat,
       ele: waypoint.ele,
-      created_at: waypoint.created_at
+      time: waypoint.time
     }
   end
 
@@ -95,13 +95,13 @@ defmodule Klaxon.Traces.Processor do
   - distance_gap: The minimum distance between trackpoints (in meters).
   ## Examples
       iex> trackpoints = [
-      ...>   %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.utc_now()},
-      ...>   %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.add(DateTime.utc_now(), 2)}
+      ...>   %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.utc_now()},
+      ...>   %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.add(DateTime.utc_now(), 2)}
       ...> ]
       iex> filter_trackpoints(trackpoints, 5, 10)
       [
-        %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.utc_now()},
-        %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.add(DateTime.utc_now(), 2)}
+        %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.utc_now()},
+        %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.add(DateTime.utc_now(), 2)}
       ]
   """
   def filter_trackpoints([], _time_gap, _distance_gap), do: []
@@ -135,7 +135,7 @@ defmodule Klaxon.Traces.Processor do
     # Calculate the distance between the two points in meters.
     distance = distance(point1, point2)
     # Calculate the time difference in seconds.
-    time_diff = abs(DateTime.diff(point1.created_at, point2.created_at, :second))
+    time_diff = abs(DateTime.diff(point1.time, point2.time, :second))
 
     distance >= distance_gap or time_diff >= time_gap
   end
@@ -176,8 +176,8 @@ defmodule Klaxon.Traces.Processor do
   - :speed: The speed (in meters/second) to use for estimating trackpoints.
   ## Examples
       iex> trackpoints = [
-      ...>   %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.utc_now()},
-      ...>   %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.add(DateTime.utc_now(), 2)}
+      ...>   %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.utc_now()},
+      ...>   %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.add(DateTime.utc_now(), 2)}
       ...> ]
       iex> process_trackpoints(trackpoints)
       {trackpoints, waypoints}
@@ -225,7 +225,7 @@ defmodule Klaxon.Traces.Processor do
           lon: lon,
           lat: lat,
           ele: elevation_of_trackpoints(trkpts),
-          created_at: datetime_of_trackpoints(trkpts)
+          time: datetime_of_trackpoints(trkpts)
         }
     end)
   end
@@ -332,8 +332,8 @@ defmodule Klaxon.Traces.Processor do
       # If the stop group only has one trackpoint, re-emit it as a go group.
       {:go, trkpts}
     else
-      start_time = hd(trkpts).created_at
-      end_time = List.last(trkpts).created_at
+      start_time = hd(trkpts).time
+      end_time = List.last(trkpts).time
       time_diff = abs(DateTime.diff(start_time, end_time, :second))
 
       if time_diff < duration do
@@ -448,7 +448,7 @@ defmodule Klaxon.Traces.Processor do
          %Trackpoint{
            lon: lon,
            lat: lat,
-           created_at:
+           time:
              estimate_time_based_on_speed(
                List.last(go_trkpts),
                %{lon: lon, lat: lat},
@@ -471,7 +471,7 @@ defmodule Klaxon.Traces.Processor do
        %Trackpoint{
          lon: lon,
          lat: lat,
-         created_at:
+         time:
            estimate_time_based_on_speed(
              List.first(go_trkpts),
              %{lon: lon, lat: lat},
@@ -517,7 +517,7 @@ defmodule Klaxon.Traces.Processor do
 
   defp emit_sorted_trackpoints({:go, trkpts}) do
     trkpts
-    |> Enum.sort(&(DateTime.to_unix(&1.created_at) < DateTime.to_unix(&2.created_at)))
+    |> Enum.sort(&(DateTime.to_unix(&1.time) < DateTime.to_unix(&2.time)))
   end
 
   # Compute center of a list of trackpoints.
@@ -582,14 +582,14 @@ defmodule Klaxon.Traces.Processor do
   - trackpoints: The list of trackpoints to process.
   ## Examples
       iex> trackpoints = [
-      ...>   %Trackpoint{created_at: DateTime.utc_now()},
-      ...>   %Trackpoint{created_at: DateTime.add(DateTime.utc_now(), 2)}
+      ...>   %Trackpoint{time: DateTime.utc_now()},
+      ...>   %Trackpoint{time: DateTime.add(DateTime.utc_now(), 2)}
       ...> ]
       iex> datetime_of_trackpoints(trackpoints)
       %DateTime{...}
   """
-  def datetime_of_trackpoints([%{created_at: first} | _] = trackpoints) do
-    last = List.last(trackpoints).created_at
+  def datetime_of_trackpoints([%{time: first} | _] = trackpoints) do
+    last = List.last(trackpoints).time
     seconds_diff = DateTime.diff(last, first, :second)
     DateTime.add(first, div(seconds_diff, 2), :second)
   end
@@ -630,7 +630,7 @@ defmodule Klaxon.Traces.Processor do
   - factor: The factor to apply to the travel time (an integer, usually 1 or -1).
   - speed: The speed to use for the travel time calculation.
   ## Examples
-      iex> trkpt1 = %Trackpoint{created_at: DateTime.utc_now(), lat: 40.1, lon: -105.1}
+      iex> trkpt1 = %Trackpoint{time: DateTime.utc_now(), lat: 40.1, lon: -105.1}
       iex> trkpt2 = %Trackpoint{lat: 40.2, lon: -105.2}
       iex> estimate_time_based_on_speed(trkpt1, trkpt2, 1, 1.4)
       %DateTime{...}
@@ -645,7 +645,7 @@ defmodule Klaxon.Traces.Processor do
         ) ::
           DateTime.t()
   def estimate_time_based_on_speed(
-        %{created_at: time, lat: _, lon: _} = trkpt1,
+        %{time: time, lat: _, lon: _} = trkpt1,
         %{lat: _, lon: _} = trkpt2,
         factor,
         speed \\ @default_speed

--- a/lib/klaxon/traces/segment.ex
+++ b/lib/klaxon/traces/segment.ex
@@ -17,7 +17,7 @@ defmodule Klaxon.Traces.Segment do
 
   schema "segments" do
     belongs_to :track, Klaxon.Traces.Track, type: EctoBase58
-    has_many :trackpoints, Klaxon.Traces.Trackpoint, preload_order: [:created_at]
+    has_many :trackpoints, Klaxon.Traces.Trackpoint, preload_order: [:time]
 
     timestamps()
   end

--- a/lib/klaxon/traces/trace.ex
+++ b/lib/klaxon/traces/trace.ex
@@ -4,7 +4,7 @@ defmodule Klaxon.Traces.Trace do
   @type t :: %__MODULE__{
           id: integer(),
           name: String.t(),
-          created_at: DateTime.t() | nil,
+          time: DateTime.t() | nil,
           profile_id: integer() | nil,
           # FIXME: Klaxon.Profiles.Profile.t()
           profile: struct() | nil,
@@ -23,11 +23,13 @@ defmodule Klaxon.Traces.Trace do
 
   schema "traces" do
     field :name, :string
-    field :created_at, :utc_datetime_usec, virtual: true
+    field :time, :utc_datetime_usec, virtual: true
+    field :status, Ecto.Enum, values: [:raw, :preprocessed, :processed], default: :raw
+    field :visibility, Ecto.Enum, values: [:private, :unlisted, :public], default: :private
 
     belongs_to :profile, Klaxon.Profiles.Profile
     has_many :tracks, Klaxon.Traces.Track
-    has_many :waypoints, Klaxon.Traces.Waypoint, preload_order: [:created_at]
+    has_many :waypoints, Klaxon.Traces.Waypoint, preload_order: [:time]
 
     timestamps()
   end

--- a/lib/klaxon/traces/trackpoint.ex
+++ b/lib/klaxon/traces/trackpoint.ex
@@ -4,7 +4,7 @@ defmodule Klaxon.Traces.Trackpoint do
   @type t :: %__MODULE__{
           id: integer(),
           name: String.t(),
-          created_at: DateTime.t(),
+          time: DateTime.t(),
           lat: float(),
           lon: float(),
           ele: float(),
@@ -14,7 +14,7 @@ defmodule Klaxon.Traces.Trackpoint do
 
   @derive {Jason.Encoder,
            only: [
-             :created_at,
+             :time,
              :lat,
              :lon,
              :ele
@@ -22,7 +22,7 @@ defmodule Klaxon.Traces.Trackpoint do
 
   schema "trackpoints" do
     field :name, :string
-    field :created_at, :utc_datetime_usec
+    field :time, :utc_datetime_usec
     field :lat, :float
     field :lon, :float
     field :ele, :float
@@ -34,6 +34,6 @@ defmodule Klaxon.Traces.Trackpoint do
   @spec changeset(struct(), map()) :: Ecto.Changeset.t()
   def changeset(trace, attrs) do
     trace
-    |> cast(attrs, [:segment_id, :name, :created_at, :lat, :lon, :ele])
+    |> cast(attrs, [:segment_id, :name, :time, :lat, :lon, :ele])
   end
 end

--- a/lib/klaxon/traces/waypoint.ex
+++ b/lib/klaxon/traces/waypoint.ex
@@ -4,7 +4,7 @@ defmodule Klaxon.Traces.Waypoint do
   @type t :: %__MODULE__{
           id: integer(),
           name: String.t(),
-          created_at: DateTime.t(),
+          time: DateTime.t(),
           lat: float(),
           lon: float(),
           ele: float(),
@@ -15,7 +15,7 @@ defmodule Klaxon.Traces.Waypoint do
   @derive {Jason.Encoder,
            only: [
              :name,
-             :created_at,
+             :time,
              :lat,
              :lon,
              :ele
@@ -23,7 +23,7 @@ defmodule Klaxon.Traces.Waypoint do
 
   schema "waypoints" do
     field :name, :string
-    field :created_at, :utc_datetime_usec
+    field :time, :utc_datetime_usec
     field :lat, :float
     field :lon, :float
     field :ele, :float
@@ -35,6 +35,6 @@ defmodule Klaxon.Traces.Waypoint do
   @spec changeset(struct(), map()) :: Ecto.Changeset.t()
   def changeset(trace, attrs) do
     trace
-    |> cast(attrs, [:trace_id, :name, :created_at, :lat, :lon, :ele])
+    |> cast(attrs, [:trace_id, :name, :time, :lat, :lon, :ele])
   end
 end

--- a/lib/klaxon_web/templates/trace/index.html.heex
+++ b/lib/klaxon_web/templates/trace/index.html.heex
@@ -7,7 +7,7 @@
 <%= if length(@traces) > 0 do %>
   <%= for trace <- @traces do %>
     <article class="mb-2">
-      <%= prettify_date(trace.created_at) %> &ndash; <%= link to: Routes.trace_path(@conn, :show, trace.id) do %><%= trace.name || "Untitled" %><% end %>
+      <%= prettify_date(trace.time) %> &ndash; <%= link to: Routes.trace_path(@conn, :show, trace.id) do %><%= trace.name || "Untitled" %><% end %>
     </article>
   <% end %>
 <% else %>

--- a/lib/klaxon_web/templates/trace/show.html.heex
+++ b/lib/klaxon_web/templates/trace/show.html.heex
@@ -8,7 +8,7 @@
 <p><ul>
   <%= for waypoint <- @trace.waypoints do %>
     <li>
-      <strong><%= waypoint.name %></strong> - Lat: <%= waypoint.lat %>, Lon: <%= waypoint.lon %>, Ele: <%= waypoint.ele %>, Time: <%= DateTime.to_iso8601(waypoint.created_at) %>
+      <strong><%= waypoint.name %></strong> - Lat: <%= waypoint.lat %>, Lon: <%= waypoint.lon %>, Ele: <%= waypoint.ele %>, Time: <%= DateTime.to_iso8601(waypoint.time) %>
     </li>
   <% end %>
 </ul>

--- a/priv/repo/migrations/20250327103624_rename_created_at.exs
+++ b/priv/repo/migrations/20250327103624_rename_created_at.exs
@@ -1,0 +1,8 @@
+defmodule Klaxon.Repo.Migrations.RenameCreatedAt do
+  use Ecto.Migration
+
+  def change do
+    rename table(:trackpoints), :created_at, to: :time
+    rename table(:waypoints), :created_at, to: :time
+  end
+end

--- a/priv/repo/migrations/20250327105255_add_traces_status_visibility.exs
+++ b/priv/repo/migrations/20250327105255_add_traces_status_visibility.exs
@@ -1,0 +1,10 @@
+defmodule Klaxon.Repo.Migrations.AddTracesStatusVisibility do
+  use Ecto.Migration
+
+  def change do
+    alter table(:traces) do
+      add :status, :string, null: false, default: "raw"
+      add :visibility, :string, null: false, default: "private"
+    end
+  end
+end

--- a/test/klaxon/traces/processor_test.exs
+++ b/test/klaxon/traces/processor_test.exs
@@ -23,8 +23,8 @@ defmodule Klaxon.Traces.ProcessorTest do
             segments: [
               %Segment{
                 trackpoints: [
-                  %Trackpoint{lat: 40.2, lon: -105.2, created_at: now},
-                  %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.add(now, 1200)}
+                  %Trackpoint{lat: 40.2, lon: -105.2, time: now},
+                  %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.add(now, 1200)}
                 ]
               }
             ]
@@ -51,7 +51,7 @@ defmodule Klaxon.Traces.ProcessorTest do
 
     test "keeps only trackpoint" do
       trackpoints = [
-        %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.utc_now()}
+        %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.utc_now()}
       ]
 
       filtered = Processor.filter_trackpoints(trackpoints, 5, 10)
@@ -61,8 +61,8 @@ defmodule Klaxon.Traces.ProcessorTest do
 
     test "keeps last trackpoint even if it does not meet time or distance requirement" do
       trackpoints = [
-        %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.utc_now()},
-        %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.add(DateTime.utc_now(), 2)}
+        %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.utc_now()},
+        %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.add(DateTime.utc_now(), 2)}
       ]
 
       filtered = Processor.filter_trackpoints(trackpoints, 5, 10)
@@ -72,9 +72,9 @@ defmodule Klaxon.Traces.ProcessorTest do
 
     test "discards trackpoint that does not meet time or distance requirement" do
       trackpoints = [
-        %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.utc_now()},
-        %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.add(DateTime.utc_now(), 2)},
-        %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.add(DateTime.utc_now(), 4)}
+        %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.utc_now()},
+        %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.add(DateTime.utc_now(), 2)},
+        %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.add(DateTime.utc_now(), 4)}
       ]
 
       filtered = Processor.filter_trackpoints(trackpoints, 5, 10)
@@ -84,9 +84,9 @@ defmodule Klaxon.Traces.ProcessorTest do
 
     test "retains trackpoint that does meet time requirement" do
       trackpoints = [
-        %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.utc_now()},
-        %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.add(DateTime.utc_now(), 6)},
-        %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.add(DateTime.utc_now(), 7)}
+        %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.utc_now()},
+        %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.add(DateTime.utc_now(), 6)},
+        %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.add(DateTime.utc_now(), 7)}
       ]
 
       filtered = Processor.filter_trackpoints(trackpoints, 5, 10)
@@ -96,9 +96,9 @@ defmodule Klaxon.Traces.ProcessorTest do
 
     test "retains trackpoint that does meet distance requirement" do
       trackpoints = [
-        %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.utc_now()},
-        %Trackpoint{lat: 40.1, lon: -105.2, created_at: DateTime.add(DateTime.utc_now(), 2)},
-        %Trackpoint{lat: 40.1, lon: -105.2, created_at: DateTime.add(DateTime.utc_now(), 4)}
+        %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.utc_now()},
+        %Trackpoint{lat: 40.1, lon: -105.2, time: DateTime.add(DateTime.utc_now(), 2)},
+        %Trackpoint{lat: 40.1, lon: -105.2, time: DateTime.add(DateTime.utc_now(), 4)}
       ]
 
       filtered = Processor.filter_trackpoints(trackpoints, 5, 10)
@@ -123,14 +123,14 @@ defmodule Klaxon.Traces.ProcessorTest do
             segments: [
               %Segment{
                 trackpoints: [
-                  %Trackpoint{lat: 40.2, lon: -105.2, created_at: now},
-                  %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.add(now, 1200)}
+                  %Trackpoint{lat: 40.2, lon: -105.2, time: now},
+                  %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.add(now, 1200)}
                 ]
               }
             ]
           }
         ],
-        waypoints: [%Waypoint{lat: 40.1, lon: -105.1, created_at: now}]
+        waypoints: [%Waypoint{lat: 40.1, lon: -105.1, time: now}]
       }
 
       processed = Processor.process_trace(trace)
@@ -151,16 +151,16 @@ defmodule Klaxon.Traces.ProcessorTest do
             segments: [
               %Segment{
                 trackpoints: [
-                  %Trackpoint{lat: 40.2, lon: -105.2, created_at: now},
-                  %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.add(now, 200)},
-                  %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.add(now, 3200)},
-                  %Trackpoint{lat: 40.0, lon: -105.0, created_at: DateTime.add(now, 3400)}
+                  %Trackpoint{lat: 40.2, lon: -105.2, time: now},
+                  %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.add(now, 200)},
+                  %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.add(now, 3200)},
+                  %Trackpoint{lat: 40.0, lon: -105.0, time: DateTime.add(now, 3400)}
                 ]
               }
             ]
           }
         ],
-        waypoints: [%Waypoint{lat: 40.1, lon: -105.1, created_at: now}]
+        waypoints: [%Waypoint{lat: 40.1, lon: -105.1, time: now}]
       }
 
       processed = Processor.process_trace(trace)
@@ -184,7 +184,7 @@ defmodule Klaxon.Traces.ProcessorTest do
       now = DateTime.utc_now()
 
       trackpoints = [
-        %Trackpoint{lat: 40.1, lon: -105.1, created_at: now}
+        %Trackpoint{lat: 40.1, lon: -105.1, time: now}
       ]
 
       {processed, _} = Processor.process_trackpoints(trackpoints)
@@ -193,19 +193,19 @@ defmodule Klaxon.Traces.ProcessorTest do
       assert trkpt = Enum.at(trkpts, 0)
       assert trkpt.lat == 40.1
       assert trkpt.lon == -105.1
-      assert trkpt.created_at == now
+      assert trkpt.time == now
     end
 
     test "correctly handles obvious stop" do
       now = DateTime.utc_now()
 
       trackpoints = [
-        %Trackpoint{lat: 40.1, lon: -105.1, created_at: now},
-        %Trackpoint{lat: 40.15, lon: -105.15, created_at: DateTime.add(now, 200)},
-        %Trackpoint{lat: 40.2, lon: -105.2, created_at: DateTime.add(now, 400)},
-        %Trackpoint{lat: 40.2, lon: -105.2, created_at: DateTime.add(now, 2400)},
-        %Trackpoint{lat: 40.25, lon: -105.25, created_at: DateTime.add(now, 2600)},
-        %Trackpoint{lat: 40.3, lon: -105.3, created_at: DateTime.add(now, 2800)}
+        %Trackpoint{lat: 40.1, lon: -105.1, time: now},
+        %Trackpoint{lat: 40.15, lon: -105.15, time: DateTime.add(now, 200)},
+        %Trackpoint{lat: 40.2, lon: -105.2, time: DateTime.add(now, 400)},
+        %Trackpoint{lat: 40.2, lon: -105.2, time: DateTime.add(now, 2400)},
+        %Trackpoint{lat: 40.25, lon: -105.25, time: DateTime.add(now, 2600)},
+        %Trackpoint{lat: 40.3, lon: -105.3, time: DateTime.add(now, 2800)}
       ]
 
       {processed, waypts} =
@@ -216,7 +216,7 @@ defmodule Klaxon.Traces.ProcessorTest do
       trkpt00 = Enum.at(trkpts0, 0)
       assert trkpt00.lat == 40.1
       assert trkpt00.lon == -105.1
-      assert trkpt00.created_at == now
+      assert trkpt00.time == now
       trkpt01 = Enum.at(trkpts0, 1)
       assert trkpt01.lat == 40.15
       assert trkpt01.lon == -105.15
@@ -224,7 +224,7 @@ defmodule Klaxon.Traces.ProcessorTest do
       trkpt10 = Enum.at(trkpts1, 0)
       assert trkpt10.lat == 40.2
       assert trkpt10.lon == -105.2
-      assert DateTime.diff(now, trkpt10.created_at) < 2600
+      assert DateTime.diff(now, trkpt10.time) < 2600
       trkpt11 = Enum.at(trkpts1, 1)
       assert trkpt11.lat == 40.25
       assert trkpt11.lon == -105.25
@@ -233,7 +233,7 @@ defmodule Klaxon.Traces.ProcessorTest do
       assert %Waypoint{} = waypt = Enum.at(waypts, 0)
       assert waypt.lat == 40.2
       assert waypt.lon == -105.2
-      assert waypt.created_at == DateTime.add(now, 1400)
+      assert waypt.time == DateTime.add(now, 1400)
     end
   end
 
@@ -316,8 +316,8 @@ defmodule Klaxon.Traces.ProcessorTest do
       trackpoints = [
         {:stop,
          [
-           %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.utc_now()},
-           %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.add(DateTime.utc_now(), 800)}
+           %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.utc_now()},
+           %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.add(DateTime.utc_now(), 800)}
          ]}
       ]
 
@@ -331,9 +331,9 @@ defmodule Klaxon.Traces.ProcessorTest do
       trackpoints = [
         {:stop,
          [
-           %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.utc_now()},
-           %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.add(DateTime.utc_now(), 400)},
-           %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.add(DateTime.utc_now(), 800)}
+           %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.utc_now()},
+           %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.add(DateTime.utc_now(), 400)},
+           %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.add(DateTime.utc_now(), 800)}
          ]}
       ]
 
@@ -420,21 +420,21 @@ defmodule Klaxon.Traces.ProcessorTest do
 
   describe "estimate_time_based_on_speed/4" do
     test "estimates time based on speed, forward" do
-      start = %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.utc_now()}
+      start = %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.utc_now()}
       stop = %Trackpoint{lat: 40.2, lon: -105.2}
       speed = 1.0
 
       time = Processor.estimate_time_based_on_speed(start, stop, 1, speed)
-      assert DateTime.diff(time, start.created_at) > 0
+      assert DateTime.diff(time, start.time) > 0
     end
 
     test "estimates time based on speed, back" do
-      stop = %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.utc_now()}
+      stop = %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.utc_now()}
       start = %Trackpoint{lat: 40.2, lon: -105.2}
       speed = 1.0
 
       time = Processor.estimate_time_based_on_speed(stop, start, -1, speed)
-      assert DateTime.diff(time, stop.created_at) < 0
+      assert DateTime.diff(time, stop.time) < 0
     end
   end
 
@@ -445,19 +445,19 @@ defmodule Klaxon.Traces.ProcessorTest do
       groups = [
         {:go,
          [
-           %Trackpoint{lon: -105.1, lat: 40.1, created_at: now},
-           %Trackpoint{lon: -105.14, lat: 40.14, created_at: DateTime.add(now, 200)},
-           %Trackpoint{lon: -105.17, lat: 40.17, created_at: DateTime.add(now, 400)}
+           %Trackpoint{lon: -105.1, lat: 40.1, time: now},
+           %Trackpoint{lon: -105.14, lat: 40.14, time: DateTime.add(now, 200)},
+           %Trackpoint{lon: -105.17, lat: 40.17, time: DateTime.add(now, 400)}
          ]},
         {:stop,
          [
-           %Trackpoint{lon: -105.2, lat: 40.2, created_at: DateTime.add(now, 2400)}
+           %Trackpoint{lon: -105.2, lat: 40.2, time: DateTime.add(now, 2400)}
          ], {-105.2, 40.2}},
         {:go,
          [
-           %Trackpoint{lon: -105.23, lat: 40.23, created_at: DateTime.add(now, 4400)},
-           %Trackpoint{lon: -105.26, lat: 40.26, created_at: DateTime.add(now, 4600)},
-           %Trackpoint{lon: -105.3, lat: 40.3, created_at: DateTime.add(now, 4800)}
+           %Trackpoint{lon: -105.23, lat: 40.23, time: DateTime.add(now, 4400)},
+           %Trackpoint{lon: -105.26, lat: 40.26, time: DateTime.add(now, 4600)},
+           %Trackpoint{lon: -105.3, lat: 40.3, time: DateTime.add(now, 4800)}
          ]}
       ]
 
@@ -467,7 +467,7 @@ defmodule Klaxon.Traces.ProcessorTest do
       {:go, go_trkpts0} = Enum.at(results0, 0)
       assert length(go_trkpts0) == 4
       last_go_trkpt0 = List.last(go_trkpts0)
-      assert %{lon: _, lat: _, created_at: last_go_created_at} = last_go_trkpt0
+      assert %{lon: _, lat: _, time: last_go_created_at} = last_go_trkpt0
       assert DateTime.diff(last_go_created_at, now) > 400
 
       results1 =
@@ -476,7 +476,7 @@ defmodule Klaxon.Traces.ProcessorTest do
       {:go, go_trkpts2} = Enum.at(results1, 2)
       assert length(go_trkpts2) == 4
       first_go_trkpt2 = List.first(go_trkpts2)
-      assert %{lat: 40.2, lon: -105.2, created_at: first_go_created_at} = first_go_trkpt2
+      assert %{lat: 40.2, lon: -105.2, time: first_go_created_at} = first_go_trkpt2
       assert DateTime.diff(first_go_created_at, now) < 4400
     end
   end
@@ -493,7 +493,7 @@ defmodule Klaxon.Traces.ProcessorTest do
       groups = [
         {:stop,
          [
-           %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.utc_now()}
+           %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.utc_now()}
          ], {40.1, -105.1}}
       ]
 
@@ -505,11 +505,11 @@ defmodule Klaxon.Traces.ProcessorTest do
       groups = [
         {:go,
          [
-           %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.utc_now()}
+           %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.utc_now()}
          ]},
         {:stop,
          [
-           %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.utc_now()}
+           %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.utc_now()}
          ], {40.1, -105.1}}
       ]
 
@@ -532,7 +532,7 @@ defmodule Klaxon.Traces.ProcessorTest do
       groups = [
         {:go,
          [
-           %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.utc_now()}
+           %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.utc_now()}
          ]}
       ]
 
@@ -544,11 +544,11 @@ defmodule Klaxon.Traces.ProcessorTest do
       groups = [
         {:go,
          [
-           %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.utc_now()}
+           %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.utc_now()}
          ]},
         {:stop,
          [
-           %Trackpoint{lat: 40.1, lon: -105.1, created_at: DateTime.utc_now()}
+           %Trackpoint{lat: 40.1, lon: -105.1, time: DateTime.utc_now()}
          ], {40.1, -105.1}}
       ]
 


### PR DESCRIPTION
- Renames `created_at` to `time` to maintain consistency with GPX format.
- Adds `visibility` and `status` fields.
- Refactors contrib module to update status of raw trace.
- Fixes bug when apply assumed step to empty trackpoint list.
