### PR TITLE
Hotfix: Remove SRI integrity from leaflet-gpx

### DIFF
--- a/lib/klaxon_web/templates/layout/root.html.heex
+++ b/lib/klaxon_web/templates/layout/root.html.heex
@@ -13,21 +13,20 @@
     <script defer src={Routes.static_path(@conn, "/assets/app.js")}></script>
 
     <!-- Leaflet CSS with SRI -->
-    <link rel="stylesheet" 
-          href="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.min.css" 
-          integrity="sha384-EdLG5Q0/L1OytQXhWSU1bWVqvLMxlmdSRaA09iy8FGYjlpP7vnB3MueQ6ZloG9oF" 
+    <link rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.min.css"
+          integrity="sha384-EdLG5Q0/L1OytQXhWSU1bWVqvLMxlmdSRaA09iy8FGYjlpP7vnB3MueQ6ZloG9oF"
           crossorigin="anonymous">
 
     <!-- Leaflet JS with SRI and defer -->
-    <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.min.js" 
-            integrity="sha384-u5N8qJeJOO2iqNjIKTdl6KeKsEikMAmCUBPc6sC6uGpgL34aPJ4VgNhuhumedpEk" 
-            crossorigin="anonymous" 
+    <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.min.js"
+            integrity="sha384-u5N8qJeJOO2iqNjIKTdl6KeKsEikMAmCUBPc6sC6uGpgL34aPJ4VgNhuhumedpEk"
+            crossorigin="anonymous"
             defer></script>
 
     <!-- Leaflet GPX Plugin with SRI and defer -->
-    <script src="https://cdn.jsdelivr.net/npm/leaflet-gpx@1.5.0/gpx.min.js" 
-            integrity="sha384-5gvz0KXfZr3Mybqx2DMfC8PDLoT3mOmDwJarx6I3SjZ4SLF5peMSAFr/TBOg1g6x" 
-            crossorigin="anonymous" 
+    <script src="https://cdn.jsdelivr.net/npm/leaflet-gpx@1.5.0/gpx.min.js"
+            crossorigin="anonymous"
             defer></script>
 
     <script defer src={Routes.static_path(@conn, "/klaxon/app.js")}></script>


### PR DESCRIPTION
Removes SRI integrity from leaflet-gpx, which is not assured due to auto-minification.