### PR TITLE
Eliminate re-encoding of known HTML

### DIFF
--- a/lib/klaxon_web/templates/checkin/list.html.heex
+++ b/lib/klaxon_web/templates/checkin/list.html.heex
@@ -6,7 +6,7 @@
         <%= if checkin.status == :draft do %><em>Draft</em> <% end %><%= link checkin.checked_in_at |> Timex.format!("%Y-%m-%d %H:%M", :strftime), to: Routes.checkin_path(@conn, :show, checkin.place, checkin) %>
         &raquo; <%= link checkin.place.title, to: Routes.place_path(@conn, :show, checkin.place) %>
         <% content = String.trim(Earmark.as_html!(snippet(checkin), inner_html: true)) %>
-        <%= if content != "" do %>&raquo; <%= content %><% end %>
+        <%= if content != "" do %>&raquo; <%= raw content %><% end %>
         <% attach_length = length(checkin.attachments) %>
         <%= if attach_length > 0 do %>&raquo; <%= attach_length %> <i class="fa-solid fa-images"></i><% end %>
       </span>

--- a/lib/klaxon_web/templates/place/list.html.heex
+++ b/lib/klaxon_web/templates/place/list.html.heex
@@ -2,7 +2,7 @@
   <%= for place <- @places do %>
     <article class="my-4 flex items-center gap-4">
       <div><img {[src: profile_media_avatar_path(@conn, place.profile), class: "rounded w-[32px] min-w-[32px] h-auto" ]}/></div>
-      <span><%= if place.status == :draft do %><em>Draft</em> <% end %><a class="link" {[href: Routes.place_path(@conn, :show, place.id)]}>&raquo; <%= String.trim(Earmark.as_html!(snippet(place), inner_html: true)) %></a></span>
+      <span><%= if place.status == :draft do %><em>Draft</em> <% end %><a class="link" {[href: Routes.place_path(@conn, :show, place.id)]}>&raquo; <%= raw String.trim(Earmark.as_html!(snippet(place), inner_html: true)) %></a></span>
     </article>
   <% end %>
 <% else %>

--- a/lib/klaxon_web/templates/place/show.html.heex
+++ b/lib/klaxon_web/templates/place/show.html.heex
@@ -42,7 +42,7 @@
         <span>
           <%= if checkin.status == :draft do %><em>Draft</em> <% end %><%= link checkin.checked_in_at |> Timex.format!("%Y-%m-%d %H:%M", :strftime), to: Routes.checkin_path(@conn, :show, @place, checkin) %>
           <% content = String.trim(Earmark.as_html!(snippet(checkin), inner_html: true)) %>
-          <%= if content != "" do %>&raquo; <%= content %><% end %>
+          <%= if content != "" do %>&raquo; <%= raw content %><% end %>
           <% attach_length = length(checkin.attachments) %>
           <%= if attach_length > 0 do %>&raquo; <%= attach_length %> <i class="fa-solid fa-images"></i><% end %>
         </span>

--- a/lib/klaxon_web/templates/post/list.html.heex
+++ b/lib/klaxon_web/templates/post/list.html.heex
@@ -9,7 +9,7 @@
             <div><img {[src: profile_media_avatar_path(@conn, post.profile), class: "rounded w-[32px] min-w-[32px] h-auto" ]}/></div>
             <span>
               <%= if post.status == :draft do %><em>Draft</em> <% end %>
-              <%= prettify_date(status_date(post), :time) %> <a class="link" {[href: Routes.post_path(@conn, :show, post.id)]}>&raquo; <%= String.trim(Earmark.as_html!(snippet(post), inner_html: true)) %></a>
+              <%= prettify_date(status_date(post), :time) %> <a class="link" {[href: Routes.post_path(@conn, :show, post.id)]}>&raquo; <%= raw String.trim(Earmark.as_html!(snippet(post), inner_html: true)) %></a>
               <% attach_length = length(post.attachments) %>
               <%= if attach_length > 0 do %>&raquo; <%= attach_length %> <i class="fa-solid fa-images"></i><% end %>
             </span>


### PR DESCRIPTION
There were a few places in the view templates where known HTML content was being re-encoded unnecessarily, causing unexpected results in particular with ampersands.

Resolves #74.